### PR TITLE
Fix for Typo in install_local_opencv.sh Affecting OpenCV Installation

### DIFF
--- a/install_local_opencv.sh
+++ b/install_local_opencv.sh
@@ -28,7 +28,7 @@ function check_package(){
 
 # ====================================================
 
-print_blue  "Configuring and building Thirdparty/opencv ..."
+print_blue  "Configuring and building thirdparty/opencv ..."
 
 set -e
 
@@ -57,7 +57,7 @@ export LD_LIBRARY_PATH=/usr/local/$CUDA_VERSION/lib64${LD_LIBRARY_PATH:+:${LD_LI
 
 # pre-installing some required packages 
 
-if [ ! -d Thirdparty/opencv ]; then
+if [ ! -d thirdparty/opencv ]; then
 	sudo apt-get update
 	sudo apt-get install -y pkg-config libglew-dev libtiff5-dev zlib1g-dev libjpeg-dev libeigen3-dev libtbb-dev libgtk2.0-dev libopenblas-dev
 
@@ -88,7 +88,7 @@ fi
 # now let's download and compile opencv and opencv_contrib
 # N.B: if you want just to update cmake settings and recompile then remove "opencv/install" and "opencv/build/CMakeCache.txt"
 
-cd Thirdparty
+cd thirdparty
 #if [ ! -d opencv/install ]; then
 if [ ! -f opencv/install/lib/libopencv_core.so ]; then
     if [ ! -d opencv ]; then


### PR DESCRIPTION
Hi @luigifreda 

Thank you for maintaining this excellent repository. While setting it up, I encountered a typo in the install_local_opencv.sh script which prevented the correct installation of OpenCV 4. The script references a directory named Thirdparty, however, the correct directory name should be thirdparty. Here's the relevant error output:

`0 to upgrade, 0 to newly install, 0 to remove and 2 not to upgrade.
./install_local_opencv.sh: line 91: cd: Thirdparty: No such file or directory`

Upon updating the directory name in the script, I was able to successfully build and install a local copy of OpenCV 4. I have submitted a PR to address this typo. Thank you for your attention to this matter.

Regards
